### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/scheduler.yml
+++ b/.github/workflows/scheduler.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Node LTS
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/.github/workflows/scheduler.yml
+++ b/.github/workflows/scheduler.yml
@@ -12,6 +12,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: write
+
 jobs:
   update-sponsors:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/1stG/static/security/code-scanning/5](https://github.com/1stG/static/security/code-scanning/5)

Add an explicit `permissions` block to the workflow to define least privilege.  
Because this workflow commits files back to the repo, it needs `contents: write`. No other permissions are shown as required by the provided steps.

Best single fix (without changing behavior): add `permissions` at the workflow root (after `concurrency` and before `jobs`) so it applies to all jobs in this workflow.

File/region to change:
- `.github/workflows/scheduler.yml`
- Insert:
  - `permissions:`
  - `  contents: write`

No imports, methods, or additional definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the scheduled repository maintenance workflow to allow automated updates to be saved back to the repo.
  * Refreshed the workflow’s checkout reference to the latest documented release label.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->